### PR TITLE
remove root 'include' from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,5 @@
 			"rootDir": "./src",
 			"outDir": "./dist"
 		}
-	},
-	"include": ["tests/**/*", "app.ts", "config.ts"]
+	}
 }


### PR DESCRIPTION
The "include" rule is no longer required as each package uses its own tsconfig.json file where they define their includes.
