### PR TITLE
99 issuance flow for user provided set of claims from mobile app

### DIFF
--- a/apps/client/app.ts
+++ b/apps/client/app.ts
@@ -173,9 +173,12 @@ export function server(protocols: Protocols): Express {
 			return res.status(response.status).send(response.body);
 		}
 
+		const pre_auth_code = (response.body as any).pre_auth_code
+
 		if (req.get("accept")?.match("text/html")) {
 			return res.status(response.status).render("issuance/credential_offer", {
 				data: {
+					pre_auth_code,
 					supportedCredentialConfigurations:
 						protocols.config.supported_credential_configurations,
 					...response.data,
@@ -188,86 +191,65 @@ export function server(protocols: Protocols): Express {
 			error_description: "accept header is missing from request",
 		});
 	});
-	
+
 	app.post("/pre-authorize", async (req, res) => {
 		let resourceOwner: ResourceOwner | null = null;
 		const authenticationError: {
-			error?: Error;
-			errorMessage?: string;
+			error ? : Error;errorMessage ? : string
 		} = {};
-	
-
-		const { pre_auth_code } = req.body || {};
-	
+		const {
+			pre_auth_code
+		} = req.body || {};
 		try {
 			const masterSecret = process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
 			const salt = "issuance-v1";
 			const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
 			const d = seedBuffer.toString('base64url');
-	
 			const privateKey = crypto.createPrivateKey({
 				key: {
 					kty: 'OKP',
 					crv: 'Ed25519',
 					x: 'unused',
-					d: d,
+					d: d
 				},
 				format: 'jwk',
-			}); 
+			});
 			const publicKey = crypto.createPublicKey(privateKey);
-	
 			let isSignatureValid = false;
-	
 			if (pre_auth_code) {
 				try {
-					const message = "stateless-grant-v1"; 
+					const message = "stateless-grant-v1";
 					isSignatureValid = crypto.verify(
-						null, 
-						Buffer.from(message), 
-						publicKey, 
+						null,
+						Buffer.from(message),
+						publicKey,
 						Buffer.from(pre_auth_code, 'base64url')
 					);
-				} catch (e) {
+				} catch {
 					isSignatureValid = false;
 				}
 			}
 			if (isSignatureValid) {
-
-				resourceOwner = { sub: "sub-123", username: "pre-authorized-user" };
+				resourceOwner = {
+					sub: "sub-123",
+					username: "pre-authorized-user"
+				};
 			} else {
 				throw new Error("Invalid pre-authorization code");
 			}
-	
 		} catch (err) {
 			resourceOwner = null;
 			authenticationError.error = new Error("Authorization Denied");
 			authenticationError.errorMessage = "The provided pre-authorization code is invalid or expired.";
-		}	
-		const response = await protocols.authorize(req, resourceOwner);
-	
-		if (response.status === 302) {
-			return res.redirect(response.location);
 		}
-	
-		const credentialConfigurations =
-			protocols.config.supported_credential_configurations?.filter(
-				(configuration) => {
-					if (response.status === 200) {
-						return response.data.authorizationRequest.scope
-							?.split(" ")
-							.includes(configuration.scope);
-					}
-				},
-			) || [];
-	
-		return res.status(response.status).render("issuance/authorize", {
-			data: {
-				credentialConfigurations,
-				...authenticationError,
-				...response.data,
-			},
-		});
+		const response = await protocols.authorize(req, resourceOwner);
+		if (response.status === 302) {
+			return res.status(200).json({
+				location: response.location
+			});
+		}
 	});
+	  
 
 	return app;
 }

--- a/apps/client/app.ts
+++ b/apps/client/app.ts
@@ -15,6 +15,8 @@ import express, { type Express } from "express";
 import { engine } from "express-handlebars";
 import Handlebars from "handlebars";
 import morgan from "morgan";
+import * as crypto from 'node:crypto'; 
+
 
 export function server(protocols: Protocols): Express {
 	const app = express();
@@ -184,6 +186,86 @@ export function server(protocols: Protocols): Express {
 		return res.status(400).send({
 			error: "invalid_request",
 			error_description: "accept header is missing from request",
+		});
+	});
+	
+	app.post("/pre-authorize", async (req, res) => {
+		let resourceOwner: ResourceOwner | null = null;
+		const authenticationError: {
+			error?: Error;
+			errorMessage?: string;
+		} = {};
+	
+
+		const { pre_auth_code } = req.body || {};
+	
+		try {
+			const masterSecret = process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
+			const salt = "issuance-v1";
+			const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
+			const d = seedBuffer.toString('base64url');
+	
+			const privateKey = crypto.createPrivateKey({
+				key: {
+					kty: 'OKP',
+					crv: 'Ed25519',
+					x: 'unused',
+					d: d,
+				},
+				format: 'jwk',
+			}); 
+			const publicKey = crypto.createPublicKey(privateKey);
+	
+			let isSignatureValid = false;
+	
+			if (pre_auth_code) {
+				try {
+					const message = "stateless-grant-v1"; 
+					isSignatureValid = crypto.verify(
+						null, 
+						Buffer.from(message), 
+						publicKey, 
+						Buffer.from(pre_auth_code, 'base64url')
+					);
+				} catch (e) {
+					isSignatureValid = false;
+				}
+			}
+			if (isSignatureValid) {
+
+				resourceOwner = { sub: "sub-123", username: "pre-authorized-user" };
+			} else {
+				throw new Error("Invalid pre-authorization code");
+			}
+	
+		} catch (err) {
+			resourceOwner = null;
+			authenticationError.error = new Error("Authorization Denied");
+			authenticationError.errorMessage = "The provided pre-authorization code is invalid or expired.";
+		}	
+		const response = await protocols.authorize(req, resourceOwner);
+	
+		if (response.status === 302) {
+			return res.redirect(response.location);
+		}
+	
+		const credentialConfigurations =
+			protocols.config.supported_credential_configurations?.filter(
+				(configuration) => {
+					if (response.status === 200) {
+						return response.data.authorizationRequest.scope
+							?.split(" ")
+							.includes(configuration.scope);
+					}
+				},
+			) || [];
+	
+		return res.status(response.status).render("issuance/authorize", {
+			data: {
+				credentialConfigurations,
+				...authenticationError,
+				...response.data,
+			},
 		});
 	});
 

--- a/apps/client/app.ts
+++ b/apps/client/app.ts
@@ -16,6 +16,8 @@ import { engine } from "express-handlebars";
 import Handlebars from "handlebars";
 import morgan from "morgan";
 import * as crypto from 'node:crypto'; 
+const stateStore = new Map<string, any>();
+
 
 
 export function server(protocols: Protocols): Express {
@@ -216,14 +218,16 @@ export function server(protocols: Protocols): Express {
 			});
 			const publicKey = crypto.createPublicKey(privateKey);
 			let isSignatureValid = false;
-			if (pre_auth_code) {
+			const { message, signed } = JSON.parse(
+				Buffer.from(pre_auth_code, "base64url").toString()
+			  );
+			if (message) {
 				try {
-					const message = "stateless-grant-v1";
 					isSignatureValid = crypto.verify(
 						null,
 						Buffer.from(message),
 						publicKey,
-						Buffer.from(pre_auth_code, 'base64url')
+						Buffer.from(signed, 'base64url')
 					);
 				} catch {
 					isSignatureValid = false;

--- a/apps/client/app.ts
+++ b/apps/client/app.ts
@@ -15,10 +15,8 @@ import express, { type Express } from "express";
 import { engine } from "express-handlebars";
 import Handlebars from "handlebars";
 import morgan from "morgan";
-import * as crypto from 'node:crypto'; 
+import * as crypto from "node:crypto";
 const stateStore = new Map<string, any>();
-
-
 
 export function server(protocols: Protocols): Express {
 	const app = express();
@@ -175,7 +173,7 @@ export function server(protocols: Protocols): Express {
 			return res.status(response.status).send(response.body);
 		}
 
-		const pre_auth_code = (response.body as any).pre_auth_code
+		const pre_auth_code = (response.body as any).pre_auth_code;
 
 		if (req.get("accept")?.match("text/html")) {
 			return res.status(response.status).render("issuance/credential_offer", {
@@ -197,37 +195,37 @@ export function server(protocols: Protocols): Express {
 	app.post("/pre-authorize", async (req, res) => {
 		let resourceOwner: ResourceOwner | null = null;
 		const authenticationError: {
-			error ? : Error;errorMessage ? : string
+			error?: Error;
+			errorMessage?: string;
 		} = {};
-		const {
-			pre_auth_code
-		} = req.body || {};
+		const { pre_auth_code } = req.body || {};
 		try {
-			const masterSecret = process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
+			const masterSecret =
+				process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
 			const salt = "issuance-v1";
 			const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
-			const d = seedBuffer.toString('base64url');
+			const d = seedBuffer.toString("base64url");
 			const privateKey = crypto.createPrivateKey({
 				key: {
-					kty: 'OKP',
-					crv: 'Ed25519',
-					x: 'unused',
-					d: d
+					kty: "OKP",
+					crv: "Ed25519",
+					x: "unused",
+					d: d,
 				},
-				format: 'jwk',
+				format: "jwk",
 			});
 			const publicKey = crypto.createPublicKey(privateKey);
 			let isSignatureValid = false;
 			const { message, signed } = JSON.parse(
-				Buffer.from(pre_auth_code, "base64url").toString()
-			  );
+				Buffer.from(pre_auth_code, "base64url").toString(),
+			);
 			if (message) {
 				try {
 					isSignatureValid = crypto.verify(
 						null,
 						Buffer.from(message),
 						publicKey,
-						Buffer.from(signed, 'base64url')
+						Buffer.from(signed, "base64url"),
 					);
 				} catch {
 					isSignatureValid = false;
@@ -236,7 +234,7 @@ export function server(protocols: Protocols): Express {
 			if (isSignatureValid) {
 				resourceOwner = {
 					sub: "sub-123",
-					username: "pre-authorized-user"
+					username: "pre-authorized-user",
 				};
 			} else {
 				throw new Error("Invalid pre-authorization code");
@@ -244,16 +242,16 @@ export function server(protocols: Protocols): Express {
 		} catch (err) {
 			resourceOwner = null;
 			authenticationError.error = new Error("Authorization Denied");
-			authenticationError.errorMessage = "The provided pre-authorization code is invalid or expired.";
+			authenticationError.errorMessage =
+				"The provided pre-authorization code is invalid or expired.";
 		}
 		const response = await protocols.authorize(req, resourceOwner);
 		if (response.status === 302) {
 			return res.status(200).json({
-				location: response.location
+				location: response.location,
 			});
 		}
 	});
-	  
 
 	return app;
 }

--- a/apps/client/app.ts
+++ b/apps/client/app.ts
@@ -1,3 +1,4 @@
+import * as crypto from "node:crypto";
 import path from "node:path";
 import {
 	type Protocols,
@@ -15,8 +16,6 @@ import express, { type Express } from "express";
 import { engine } from "express-handlebars";
 import Handlebars from "handlebars";
 import morgan from "morgan";
-import * as crypto from "node:crypto";
-const stateStore = new Map<string, any>();
 
 export function server(protocols: Protocols): Express {
 	const app = express();
@@ -173,7 +172,8 @@ export function server(protocols: Protocols): Express {
 			return res.status(response.status).send(response.body);
 		}
 
-		const pre_auth_code = (response.body as any).pre_auth_code;
+		const pre_auth_code = (response.body as Record<string, string>)
+			.pre_auth_code;
 
 		if (req.get("accept")?.match("text/html")) {
 			return res.status(response.status).render("issuance/credential_offer", {
@@ -242,8 +242,7 @@ export function server(protocols: Protocols): Express {
 		} catch (err) {
 			resourceOwner = null;
 			authenticationError.error = new Error("Authorization Denied");
-			authenticationError.errorMessage =
-				"The provided pre-authorization code is invalid or expired.";
+			authenticationError.errorMessage = (err as Error).message;
 		}
 		const response = await protocols.authorize(req, resourceOwner);
 		if (response.status === 302) {

--- a/apps/client/views/issuance/credential_offer.handlebars
+++ b/apps/client/views/issuance/credential_offer.handlebars
@@ -11,7 +11,7 @@
 <main class="main" onclick="hideConfigurations()">
     <div class="heading">
         <h1>Obtain your credential</h1>
-        <p style="font-size: 0.8em; color: #666; word-break: break-all;">Code: {{@pre_auth_code}}</p>
+        <p style="font-size: 0.8em; color: #666; word-break: break-all;">Pre-authorized-code :  {{@pre_auth_code}}</p>
     </div>
 
     <div class="content">

--- a/apps/client/views/issuance/credential_offer.handlebars
+++ b/apps/client/views/issuance/credential_offer.handlebars
@@ -1,60 +1,345 @@
-<header><img class="logo" onclick="toggleConfigurations()" src="/img/wwwallet-logo.png" /></header>
+<header>
+    <img class="logo" onclick="toggleConfigurations(event)" src="/img/wwwallet-logo.png" style="cursor:pointer" />
+</header>
 
-<div class="supported-credential-configurations">
-  {{#each @supportedCredentialConfigurations}}
-  <a class="credential-configuration" href="/offer/{{this.scope}}">{{this.label}}</a>
-  {{/each}}
+<div class="supported-credential-configurations" style="display:none; position:absolute; background:white; border:1px solid #ccc; padding:10px; z-index:100;">
+    {{#each @supportedCredentialConfigurations}}
+        <a class="credential-configuration" href="/offer/{{this.scope}}">{{this.label}}</a>
+    {{/each}}
 </div>
 
-<script>
-function toggleConfigurations () {
-  Array.prototype.forEach.call(
-    document.getElementsByClassName("supported-credential-configurations"),
-    (elt) => {
-      if (elt.style.display === "block") {
-        elt.style.display = "none"
-      } else {
-        elt.style.display = "block"
-      }
-    }
-  )
-
-}
-</script>
-
 <main class="main" onclick="hideConfigurations()">
-  <div class="heading">
-    <h1>Obtain your credential</h1>
-    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris sodales accumsan cursus. Aenean elementum id ipsum sit amet consectetur. Donec purus tortor, viverra at iaculis vel, volutpat in ipsum. Nunc dapibus dolor mi, vel porta arcu eleifend in. Praesent non nisi lorem. Vestibulum malesuada sollicitudin porttitor.</p>
-    <p>Donec a tincidunt quam. Sed eget augue sit amet dolor pharetra rutrum ac id arcu. Curabitur vestibulum sem ex, sed porttitor orci lacinia et. Etiam aliquam quam id rutrum consequat. Duis id diam velit. Quisque malesuada massa magna, in rhoncus orci varius quis. Sed quis tortor neque.</p>
-  </div>
-  <div class="content">
-    <div class="credential-offer">
-      <div class="title">
-        {{#each @credentialConfigurations}}
-          <h2>{{this.label}}</h2>
-        {{/each}}
-      </div>
-      {{#if @error}}
-      <h2 class="selection">Select a credential</h2>
-      {{else}}
-      <div class="qrcode">
-        <img src="{{{@credentialOfferQrCode}}}" />
-      </div>
-      <a class="button fluid" href="{{{@credentialOfferUrl}}}">Get credential</a>
-      {{/if}}
+    <div class="heading">
+        <h1>Obtain your credential</h1>
+        <p style="font-size: 0.8em; color: #666; word-break: break-all;">Code: {{@pre_auth_code}}</p>
     </div>
-  </div>
+
+    <div class="content">
+        <div class="credential-offer">
+            <div class="title">
+                {{#each @credentialConfigurations}}
+                    <h2>{{this.label}}</h2>
+                {{/each}}
+            </div>
+
+            {{#if @error}}
+                <h2 class="selection">Select a credential</h2>
+            {{else}}
+                <div class="qrcode" style="text-align:center; margin:20px;">
+                    <img src="{{{@credentialOfferQrCode}}}" />
+                </div>
+
+                <a class="button fluid" href="{{{@credentialOfferUrl}}}" id="claimButton" onclick="handleClaim(event, '{{@pre_auth_code}}', '{{@credentialOfferUrl}}')">
+                    Get credential
+                </a>
+            {{/if}}
+        </div> <!-- end of credential-offer -->
+    </div> <!-- end of content -->
+
+    <div id="credential-result" style="display:none; width: 100%; max-width: 600px; margin: 20px auto; padding: 20px; border: 1px solid #dfdfdf; border-radius: 10px; background: #fff;">
+        <h1>Issued Credential</h1>
+        <pre id="credential-json" style="background: #f9f9f9; border: 1px solid #ccc; padding: 15px; overflow: auto; font-family: monospace; font-size: 0.9em;"></pre>
+        <button class="button" onclick="location.reload()">Get Another</button>
+    </div>
 </main>
-
 <script>
-function hideConfigurations () {
-  Array.prototype.forEach.call(
-    document.getElementsByClassName("supported-credential-configurations"),
-    (elt) => {
-      elt.style.display = "none"
-    }
-  )
+    /**
+     * Helper to perform a POST navigation (redirect with body data)
+     */
+    function navigatePost(url, data) {
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = url;
 
-}
+        for (const key in data) {
+            if (data.hasOwnProperty(key)) {
+                const input = document.createElement('input');
+                input.type = 'hidden';
+                input.name = key;
+                input.value = data[key];
+                form.appendChild(input);
+            }
+        }
+
+        document.body.appendChild(form);
+        form.submit();
+    }
+
+
+    function b64UrlEncode(data) {
+        // data: Uint8Array or string
+        if (typeof data === "string") {
+            data = new TextEncoder().encode(data);
+        }
+        let binary = "";
+        for (let i = 0; i < data.byteLength; i++) {
+            binary += String.fromCharCode(data[i]);
+        }
+        return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    }
+
+    // --- Generate EC P-256 keys ---
+    async function generateKeys() {
+        const keyPair = await crypto.subtle.generateKey({
+                name: "ECDSA",
+                namedCurve: "P-256"
+            },
+            true,
+            ["sign", "verify"]
+        );
+
+        const jwk = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+        // Keep only required fields
+        const publicJwk = {
+            kty: jwk.kty,
+            crv: jwk.crv,
+            x: jwk.x,
+            y: jwk.y,
+        };
+
+        return {
+            privateKey: keyPair.privateKey,
+            jwk: publicJwk
+        };
+    }
+    // --- SHA-256 hash helper ---
+    async function sha256(data) {
+        if (typeof data === "string") data = new TextEncoder().encode(data);
+        const hash = await crypto.subtle.digest("SHA-256", data);
+        return new Uint8Array(hash);
+    }
+
+    async function signRaw(privateKey, data) {
+        if (typeof data === "string") data = new TextEncoder().encode(data);
+
+        // Sign using ECDSA P-256 with SHA-256
+        const signature = await crypto.subtle.sign({
+                name: "ECDSA",
+                hash: "SHA-256"
+            },
+            privateKey,
+            data
+        );
+
+        // In browser, this is already a raw r||s 64-byte ArrayBuffer
+        return new Uint8Array(signature);
+    }
+
+    // --- Generate DPoP JWT ---
+    async function generateDpop(accessToken, htu = "http://localhost:5000/credential") {
+        const {
+            privateKey,
+            jwk
+        } = await generateKeys();
+        const athHash = await sha256(accessToken);
+        const ath = b64UrlEncode(athHash);
+
+        const header = {
+            typ: "dpop+jwt",
+            alg: "ES256",
+            jwk
+        };
+        const payload = {
+            jti: "jti",
+            htm: "POST",
+            htu,
+            iat: Math.floor(Date.now() / 1000),
+            ath,
+        };
+
+        const encoded = `${b64UrlEncode(JSON.stringify(header))}.${b64UrlEncode(JSON.stringify(payload))}`;
+        const sig = await signRaw(privateKey, encoded);
+        return `${encoded}.${b64UrlEncode(sig)}`;
+    }
+
+    // --- Generate Proof JWT ---
+    async function generateProof(nonce) {
+        const {
+            privateKey,
+            jwk
+        } = await generateKeys();
+        const header = {
+            alg: "ES256",
+            jwk
+        };
+        const payload = {
+            nonce
+        };
+
+        const encoded = `${b64UrlEncode(JSON.stringify(header))}.${b64UrlEncode(JSON.stringify(payload))}`;
+        const sig = await signRaw(privateKey, encoded);
+        return `${encoded}.${b64UrlEncode(sig)}`;
+    }
+
+    // from k6 documentation
+    function string2ArrayBuffer(str) {
+        const buf = new ArrayBuffer(str.length);
+        const bufView = new Uint8Array(buf);
+        for (let i = 0, strLen = str.length; i < strLen; i++) {
+            bufView[i] = str.charCodeAt(i);
+        }
+        return buf;
+    }
+
+    async function handleClaim(event, preAuthCode, offerUrl) {
+        // 1. Prevent default anchor behavior
+        if (event) event.preventDefault();
+
+        const BASE_URL = "http://localhost:5000"; // Issuer URL
+        const WALLET_URL = "http://localhost:3000"; // Your current Wallet URL
+        const client_id = "CLIENT123";
+
+        // UI Feedback: Disable button to prevent double clicks
+        const btn = document.getElementById('claimButton');
+        const originalText = btn.innerText;
+        btn.innerText = "Processing...";
+        btn.style.pointerEvents = "none";
+        btn.style.opacity = "0.6";
+
+        try {
+            // 2. Extract issuer_state from the offerUrl
+            const regex = /issuer_state%22%3A%22([^%]+)%22/;
+            const match = offerUrl.match(regex);
+            if (!match) {
+                throw new Error("Could not find issuer_state in the offer.");
+            }
+            const issuerState = match[1];
+
+            // 3. Step 1: Pushed Authorization Request (PAR)
+            const parResponse = await fetch(`${BASE_URL}/pushed-authorization-request`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: new URLSearchParams({
+                    "response_type": "code",
+                    "client_id": client_id,
+                    "redirect_uri": WALLET_URL,
+                    "scope": "pid:sd_jwt_dc",
+                    "issuer_state": issuerState,
+                    "code_challenge": "n4bQgYhMfWWaL-qgxVrQFaO_TxsrC4Is0V1sFbDwCgg",
+                    "code_challenge_method": "S256"
+                })
+            });
+
+            if (!parResponse.ok) throw new Error("PAR Request failed");
+            const parData = await parResponse.json();
+            const request_uri = parData.request_uri;
+
+            // 4. Step 2: Initialize Authorization
+            await fetch(`${BASE_URL}/authorize?client_id=${client_id}&request_uri=${request_uri}`);
+
+            // 5. Step 3: Authenticate / Pre-Authorize
+            const authBody = new URLSearchParams({
+                pre_auth_code: preAuthCode
+            });
+            const authenticate = await fetch(
+                `${BASE_URL}/pre-authorize?client_id=${client_id}&request_uri=${request_uri}`, {
+                    method: "POST",
+                    body: authBody,
+                    redirect: "manual",
+                }
+            );
+
+            const authData = await authenticate.json();
+            if (!authData.location) throw new Error("No redirect location received from pre-authorize");
+
+            // 6. Step 4: Extract Authorization Code
+            const [, authorization_code] = /code=([^&]+)/.exec(authData.location) || [];
+            if (!authorization_code) throw new Error("Failed to extract authorization code");
+
+            // 7. Step 5: Exchange Code for Access Token
+            const tokenBody = new URLSearchParams({
+                client_id: client_id,
+                redirect_uri: WALLET_URL,
+                grant_type: "authorization_code",
+                code: authorization_code,
+                code_verifier: "test"
+            });
+
+            const tokenResp = await fetch(`${BASE_URL}/token`, {
+                method: "POST",
+                body: tokenBody
+            });
+            const tokenData = await tokenResp.json();
+            const access_token = tokenData.access_token;
+
+            // 8. Step 6: Get Nonce for Proof
+            const nonceResp = await fetch(`${BASE_URL}/nonce`, {
+                method: "POST"
+            });
+            const nonceData = await nonceResp.json();
+            const c_nonce = nonceData.c_nonce;
+
+            // 9. Step 7: Generate Proofs (DPoP and Proof JWT)
+            const dpop_jwt = await generateDpop(access_token);
+            const proof_jwt = await generateProof(c_nonce);
+
+            // 10. Step 8: Final Credential Request
+            const credResp = await fetch(`${BASE_URL}/credential`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${access_token}`,
+                    "DPoP": dpop_jwt
+                },
+                body: JSON.stringify({
+                    credential_configuration_ids: ["urn:eudi:pid:1:dc"],
+                    proofs: {
+                        jwt: [proof_jwt]
+                    }
+                }),
+            });
+
+            const credData = await credResp.json();
+
+            // 11. Step 9: Render Result in Page
+            // Hide the current UI components
+            document.querySelector('.content').style.display = 'none';
+            document.querySelector('.heading').style.display = 'none';
+
+            // Check if result container exists, if not, create it
+            let resultContainer = document.getElementById('credential-result');
+            if (!resultContainer) {
+                resultContainer = document.createElement('div');
+                resultContainer.id = 'credential-result';
+                resultContainer.className = 'credential-offer'; // Reuse existing styles
+                resultContainer.style.maxWidth = '600px';
+                resultContainer.style.margin = '20px auto';
+                document.querySelector('.main').appendChild(resultContainer);
+            }
+
+            resultContainer.innerHTML = `
+            <div class="title"><h2>Success</h2></div>
+            <p>Credential Issued Successfully</p>
+            <pre style="text-align:left; background:#f4f4f4; padding:15px; overflow:auto; font-size:11px;">${JSON.stringify(credData, null, 2)}</pre>
+            <button class="button fluid" onclick="location.reload()">Back to Offer</button>
+        `;
+            resultContainer.style.display = 'block';
+
+        } catch (err) {
+            console.error("Issuance flow failed:", err);
+            alert("Authorization failed: " + err.message);
+
+            // Reset button state
+            btn.innerText = originalText;
+            btn.style.pointerEvents = "auto";
+            btn.style.opacity = "1";
+        }
+    }
+    // UI Helpers
+    function toggleConfigurations(event) {
+        event.stopPropagation();
+        const elts = document.getElementsByClassName("supported-credential-configurations");
+        for (let elt of elts) {
+            elt.style.display = (elt.style.display === "block") ? "none" : "block";
+        }
+    }
+
+    function hideConfigurations() {
+        const elts = document.getElementsByClassName("supported-credential-configurations");
+        for (let elt of elts) {
+            elt.style.display = "none";
+        }
+    }
 </script>

--- a/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
+++ b/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
@@ -10,7 +10,7 @@ import {
 	validateScope,
 } from "../../statements";
 import { credentialOfferHandlerConfigSchema } from "./schemas";
-import crypto from 'node:crypto';
+import crypto from "node:crypto";
 
 const ajv = new Ajv();
 
@@ -47,88 +47,89 @@ export type CredentialOfferResponse = {
 };
 
 export function credentialOfferHandlerFactory(
-    config: CredentialOfferHandlerConfig,
+	config: CredentialOfferHandlerConfig,
 ) {
-    return async function credentialOfferHandler(
-        expressRequest: Request,
-    ): Promise<CredentialOfferResponse | OauthErrorResponse> {
-        try {
-            // 1. Derive Deterministic Key
-            const masterSecret = process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
-            const salt = "issuance-v1";
-            
-            // Generate the 32-byte seed
-            const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
-            const d = seedBuffer.toString('base64url');
+	return async function credentialOfferHandler(
+		expressRequest: Request,
+	): Promise<CredentialOfferResponse | OauthErrorResponse> {
+		try {
+			// 1. Derive Deterministic Key
+			const masterSecret =
+				process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
+			const salt = "issuance-v1";
 
-            // 2. Create the Private Key using JWK format (Very compatible)
-            // Ed25519 JWK: kty=OKP, crv=Ed25519, d=private_key_bytes
-            const derivedKey = crypto.createPrivateKey({
-                key: {
-                    kty: 'OKP',
-                    crv: 'Ed25519',
-                    x: 'unused', // Public part; for import-only, Node allows junk or empty
-                    d: d,
-                },
-                format: 'jwk',
-            });
+			// Generate the 32-byte seed
+			const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
+			const d = seedBuffer.toString("base64url");
 
-            // 3. Prepare the payload to sign
-            const payload = JSON.stringify({
-                iat: Math.floor(Date.now() / 1000),
-                nonce: crypto.randomBytes(16).toString('hex')
-            });
+			// 2. Create the Private Key using JWK format (Very compatible)
+			// Ed25519 JWK: kty=OKP, crv=Ed25519, d=private_key_bytes
+			const derivedKey = crypto.createPrivateKey({
+				key: {
+					kty: "OKP",
+					crv: "Ed25519",
+					x: "unused", // Public part; for import-only, Node allows junk or empty
+					d: d,
+				},
+				format: "jwk",
+			});
 
-            const random = crypto.randomBytes(32).toString("base64url");
+			// 3. Prepare the payload to sign
+			const payload = JSON.stringify({
+				iat: Math.floor(Date.now() / 1000),
+				nonce: crypto.randomBytes(16).toString("hex"),
+			});
 
-            const message = `stateless-grant-v1:${random}`;
+			const random = crypto.randomBytes(32).toString("base64url");
+
+			const message = `stateless-grant-v1:${random}`;
 			const signed = (crypto.sign as any)(
-				null, 
-				Buffer.from(message), 
-				derivedKey
-			).toString('base64url');
+				null,
+				Buffer.from(message),
+				derivedKey,
+			).toString("base64url");
 
-            const pre_auth_code = Buffer.from(
-                JSON.stringify({ message, signed })
-              ).toString("base64url");
-            // --- Framework Standard logic ---
-            const request = await validateRequest(expressRequest);
-            const { client } = await issuerClient(config);
-            const { scope } = await validateScope(request.scope, { client }, config);
-            const { grants } = await generateIssuerGrants({ client }, config);
+			const pre_auth_code = Buffer.from(
+				JSON.stringify({ message, signed }),
+			).toString("base64url");
+			// --- Framework Standard logic ---
+			const request = await validateRequest(expressRequest);
+			const { client } = await issuerClient(config);
+			const { scope } = await validateScope(request.scope, { client }, config);
+			const { grants } = await generateIssuerGrants({ client }, config);
 
-            // 5. Inject the Pre-Auth Grant
-            (grants as any)["urn:ietf:params:oauth:grant-type:pre-authorized_code"] = {
-                "pre-authorized_code": pre_auth_code,
-                "user_pin_required": false 
-            };
+			// 5. Inject the Pre-Auth Grant
+			(grants as any)["urn:ietf:params:oauth:grant-type:pre-authorized_code"] =
+				{
+					"pre-authorized_code": pre_auth_code,
+					user_pin_required: false,
+				};
 
-            const {
-                credentialOfferUrl,
-                credentialOfferQrCode,
-                credentialConfigurations,
-            } = await generateCredentialOffer({ grants, scope }, config);
-            
-            return {
-                status: 200,
-                data: {
-                    credentialOfferUrl,
-                    credentialOfferQrCode,
-                    credentialConfigurations,
-                },
-                body: {
-                    
-                    pre_auth_code,
-                    credential_offer_url: credentialOfferUrl,
-                    credential_offer_qrcode: credentialOfferQrCode,
-                },
-            };
-        } catch (error: any) {
-            console.error("Handler Error:", error.message);
-            if (error instanceof OauthError) return error.toResponse();
-            throw error;
-        }
-    };
+			const {
+				credentialOfferUrl,
+				credentialOfferQrCode,
+				credentialConfigurations,
+			} = await generateCredentialOffer({ grants, scope }, config);
+
+			return {
+				status: 200,
+				data: {
+					credentialOfferUrl,
+					credentialOfferQrCode,
+					credentialConfigurations,
+				},
+				body: {
+					pre_auth_code,
+					credential_offer_url: credentialOfferUrl,
+					credential_offer_qrcode: credentialOfferQrCode,
+				},
+			};
+		} catch (error: any) {
+			console.error("Handler Error:", error.message);
+			if (error instanceof OauthError) return error.toResponse();
+			throw error;
+		}
+	};
 }
 
 export function validateCredentialOfferHandlerConfig(config: Config) {

--- a/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
+++ b/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
@@ -79,15 +79,18 @@ export function credentialOfferHandlerFactory(
                 nonce: crypto.randomBytes(16).toString('hex')
             });
 
-			const message = "stateless-grant-v1"; 
-			const pre_auth_code = (crypto.sign as any)(
+            const random = crypto.randomBytes(32).toString("base64url");
+
+            const message = `stateless-grant-v1:${random}`;
+			const signed = (crypto.sign as any)(
 				null, 
 				Buffer.from(message), 
 				derivedKey
 			).toString('base64url');
 
-
-
+            const pre_auth_code = Buffer.from(
+                JSON.stringify({ message, signed })
+              ).toString("base64url");
             // --- Framework Standard logic ---
             const request = await validateRequest(expressRequest);
             const { client } = await issuerClient(config);
@@ -105,7 +108,7 @@ export function credentialOfferHandlerFactory(
                 credentialOfferQrCode,
                 credentialConfigurations,
             } = await generateCredentialOffer({ grants, scope }, config);
-
+            
             return {
                 status: 200,
                 data: {
@@ -114,6 +117,7 @@ export function credentialOfferHandlerFactory(
                     credentialConfigurations,
                 },
                 body: {
+                    
                     pre_auth_code,
                     credential_offer_url: credentialOfferUrl,
                     credential_offer_qrcode: credentialOfferQrCode,

--- a/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
+++ b/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
@@ -10,6 +10,7 @@ import {
 	validateScope,
 } from "../../statements";
 import { credentialOfferHandlerConfigSchema } from "./schemas";
+import crypto from 'node:crypto';
 
 const ajv = new Ajv();
 
@@ -39,68 +40,91 @@ export type CredentialOfferResponse = {
 		credentialConfigurations: Array<CredentialConfiguration>;
 	};
 	body: {
+		pre_auth_code: string;
 		credential_offer_url: string;
 		credential_offer_qrcode: string;
 	};
 };
 
 export function credentialOfferHandlerFactory(
-	config: CredentialOfferHandlerConfig,
+    config: CredentialOfferHandlerConfig,
 ) {
-	return async function credentialOfferHandler(
-		expressRequest: Request,
-	): Promise<CredentialOfferResponse | OauthErrorResponse> {
-		try {
-			const request = await validateRequest(expressRequest);
+    return async function credentialOfferHandler(
+        expressRequest: Request,
+    ): Promise<CredentialOfferResponse | OauthErrorResponse> {
+        try {
+            // 1. Derive Deterministic Key
+            const masterSecret = process.env.ISSUER_MASTER_SECRET || "secure-permanent-secret";
+            const salt = "issuance-v1";
+            
+            // Generate the 32-byte seed
+            const seedBuffer = crypto.scryptSync(masterSecret, salt, 32);
+            const d = seedBuffer.toString('base64url');
 
-			const { client } = await issuerClient(config);
+            // 2. Create the Private Key using JWK format (Very compatible)
+            // Ed25519 JWK: kty=OKP, crv=Ed25519, d=private_key_bytes
+            const derivedKey = crypto.createPrivateKey({
+                key: {
+                    kty: 'OKP',
+                    crv: 'Ed25519',
+                    x: 'unused', // Public part; for import-only, Node allows junk or empty
+                    d: d,
+                },
+                format: 'jwk',
+            });
 
-			const { scope } = await validateScope(request.scope, { client }, config);
+            // 3. Prepare the payload to sign
+            const payload = JSON.stringify({
+                iat: Math.floor(Date.now() / 1000),
+                nonce: crypto.randomBytes(16).toString('hex')
+            });
 
-			const { grants } = await generateIssuerGrants({ client }, config);
+			const message = "stateless-grant-v1"; 
+			const pre_auth_code = (crypto.sign as any)(
+				null, 
+				Buffer.from(message), 
+				derivedKey
+			).toString('base64url');
 
-			const {
-				credentialOfferUrl,
-				credentialOfferQrCode,
-				credentialConfigurations,
-			} = await generateCredentialOffer(
-				{
-					grants,
-					scope,
-				},
-				config,
-			);
 
-			config.logger.business("credential_offer", {
-				client_id: client.id,
-				scope,
-				credential_configuration_ids: credentialConfigurations
-					.map(({ credential_configuration_id }) => credential_configuration_id)
-					.join(","),
-			});
-			return {
-				status: 200,
-				data: {
-					credentialOfferUrl,
-					credentialOfferQrCode,
-					credentialConfigurations,
-				},
-				body: {
-					credential_offer_url: credentialOfferUrl,
-					credential_offer_qrcode: credentialOfferQrCode,
-				},
-			};
-		} catch (error) {
-			if (error instanceof OauthError) {
-				config.logger.business("credential_offer_error", {
-					error: error.message,
-				});
-				return error.toResponse();
-			}
 
-			throw error;
-		}
-	};
+            // --- Framework Standard logic ---
+            const request = await validateRequest(expressRequest);
+            const { client } = await issuerClient(config);
+            const { scope } = await validateScope(request.scope, { client }, config);
+            const { grants } = await generateIssuerGrants({ client }, config);
+
+            // 5. Inject the Pre-Auth Grant
+            (grants as any)["urn:ietf:params:oauth:grant-type:pre-authorized_code"] = {
+                "pre-authorized_code": pre_auth_code,
+                "user_pin_required": false 
+            };
+
+            const {
+                credentialOfferUrl,
+                credentialOfferQrCode,
+                credentialConfigurations,
+            } = await generateCredentialOffer({ grants, scope }, config);
+
+            return {
+                status: 200,
+                data: {
+                    credentialOfferUrl,
+                    credentialOfferQrCode,
+                    credentialConfigurations,
+                },
+                body: {
+                    pre_auth_code,
+                    credential_offer_url: credentialOfferUrl,
+                    credential_offer_qrcode: credentialOfferQrCode,
+                },
+            };
+        } catch (error: any) {
+            console.error("Handler Error:", error.message);
+            if (error instanceof OauthError) return error.toResponse();
+            throw error;
+        }
+    };
 }
 
 export function validateCredentialOfferHandlerConfig(config: Config) {

--- a/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
+++ b/packages/server-core/src/handlers/protocols/credentialOffer.handler.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import Ajv from "ajv";
 import type { Request } from "express";
 import type { Config, Logger } from "../../config";
@@ -10,7 +11,6 @@ import {
 	validateScope,
 } from "../../statements";
 import { credentialOfferHandlerConfigSchema } from "./schemas";
-import crypto from "node:crypto";
 
 const ajv = new Ajv();
 
@@ -74,16 +74,11 @@ export function credentialOfferHandlerFactory(
 				format: "jwk",
 			});
 
-			// 3. Prepare the payload to sign
-			const payload = JSON.stringify({
-				iat: Math.floor(Date.now() / 1000),
-				nonce: crypto.randomBytes(16).toString("hex"),
-			});
-
+			// 3. Prepare the message to sign
 			const random = crypto.randomBytes(32).toString("base64url");
 
 			const message = `stateless-grant-v1:${random}`;
-			const signed = (crypto.sign as any)(
+			const signed = (crypto.sign as unknown as Function)(
 				null,
 				Buffer.from(message),
 				derivedKey,
@@ -99,11 +94,12 @@ export function credentialOfferHandlerFactory(
 			const { grants } = await generateIssuerGrants({ client }, config);
 
 			// 5. Inject the Pre-Auth Grant
-			(grants as any)["urn:ietf:params:oauth:grant-type:pre-authorized_code"] =
-				{
-					"pre-authorized_code": pre_auth_code,
-					user_pin_required: false,
-				};
+			(grants as Record<string, unknown>)[
+				"urn:ietf:params:oauth:grant-type:pre-authorized_code"
+			] = {
+				"pre-authorized_code": pre_auth_code,
+				user_pin_required: false,
+			};
 
 			const {
 				credentialOfferUrl,
@@ -124,8 +120,8 @@ export function credentialOfferHandlerFactory(
 					credential_offer_qrcode: credentialOfferQrCode,
 				},
 			};
-		} catch (error: any) {
-			console.error("Handler Error:", error.message);
+		} catch (error: unknown) {
+			console.error("Handler Error:", (error as Error).message);
 			if (error instanceof OauthError) return error.toResponse();
 			throw error;
 		}


### PR DESCRIPTION
The implementation is as follows, assuming the user does not need to log in to obtain the VC. It follows the specification: [Pre-Authorized Code Flow](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-pre-authorized-code-flow)
.
1, By querying api.endpoint/offer/pid:sd_jwt_dc, step 1 is fulfilled.

2, The user receives a unique pre-authorized code signed by the issuer (steps 2 and 3).

3, By clicking Get Credential, the pre-authorized code is attached, a token is requested from the authorization service, and that token is then used to obtain the VC (steps 4 and 5).